### PR TITLE
2 New features added and 1 issue fixed

### DIFF
--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -143,32 +143,10 @@
       // update flag on keyup
       // (by extracting the dial code from the input value)
       this.telInput.keyup(function() {
-        var countryCode, alreadySelected = false;
-        // try and extract valid dial code from input
-        var dialCode = that._getDialCode(that.telInput.val());
-        if (dialCode) {
-          // check if one of the matching country's is already selected
-          var countryCodes = intlData.countryCodes[dialCode];
-          $.each(countryCodes, function(i, c) {
-            if (that.selectedFlagInner.hasClass(c)) {
-              alreadySelected = true;
-            }
-          });
-          countryCode = countryCodes[0];
-        }
-        // else default to dialcode of the first preferred country
-        else {
-          countryCode = that.defaultCountry.cca2;
-        }
-
-        if (!alreadySelected) {
-          that._selectFlag(countryCode);
-        }
+          that._performKeyUpAction(that) ;
       });
       // trigger it now in case there is already a number in the input
-      this.telInput.keyup();
-
-
+      that._performKeyUpAction(that) ;
 
       // toggle country dropdown on click
       selectedFlag.click(function(e) {
@@ -267,6 +245,7 @@
       this.countryListItems.click(function(e) {
         var listItem = $(e.currentTarget);
         that._selectListItem(listItem);
+        that.telInput.focus() ;
       });
 
     }, // end of init()
@@ -277,7 +256,29 @@
     /********************
      *  PRIVATE METHODS
      ********************/
+    _performKeyUpAction: function(intlInput) {
+        var countryCode, alreadySelected = false;
+        // try and extract valid dial code from input
+        var dialCode = intlInput._getDialCode(intlInput.telInput.val());
+        if (dialCode) {
+            // check if one of the matching country's is already selected
+            var countryCodes = intlData.countryCodes[dialCode];
+            $.each(countryCodes, function(i, c) {
+                if (intlInput.selectedFlagInner.hasClass(c)) {
+                    alreadySelected = true;
+                }
+            });
+            countryCode = countryCodes[0];
+        }
+        // else default to dialcode of the first preferred country
+        else {
+            countryCode = intlInput.defaultCountry.cca2;
+        }
 
+        if (!alreadySelected) {
+            intlInput._selectFlag(countryCode);
+        }
+    },
 
     // find the country data for the given country code
     _getCountryData: function(countryCode) {
@@ -304,12 +305,15 @@
     _selectListItem: function(listItem) {
       var countryCode = listItem.attr("data-country-code");
       // update selected flag
-      this.selectedFlagInner.attr("class", "flag " + countryCode);
+      //this.selectedFlagInner.attr("class", "flag " + countryCode);
       // update input value
       var newNumber = this._updateNumber(this.telInput.val(), listItem.attr("data-dial-code"));
       this.telInput.val(newNumber);
       // focus the input
       this.telInput.focus();
+      // triggers the keyup event
+      this.telInput.keyup();
+
       // mark the list item as active (incase they open the dropdown again)
       this.countryListItems.removeClass("active highlight");
       listItem.addClass("active");
@@ -428,6 +432,11 @@
      *  PUBLIC METHODS
      ********************/
 
+    // modify the value and updates the flag
+    val: function(number) {
+        this.telInput.val(number) ;
+        this._performKeyUpAction(this) ;
+    },
 
     // update the selected flag, and insert the dial code
     selectCountry: function(countryCode) {


### PR DESCRIPTION
Fixed the following issue: when using the up and down arrow to scroll the countries list, the entire page is also scrolled.
To solve it I added some code to make the country list gain the focus when clicking on the flag.

Added the ability to disable the separation of the dialing code using a white space dirven by the split mode (TRUE/false) parameter.

Erase the content of the field when it looses focus if only the dialing code is present. Recover it when it gains the focus. This avoids forcing the user to remove the value if he doesn't want to send it.
