### PR TITLE
Fix changing countries when you have a string like "+1.3451234567"

### DIFF
--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -371,6 +371,25 @@
     },
 
 
+    // like indexOf + length, but ignores characters in the middle of a match
+    _findEndOfStringIgnoreNonConsecutive: function(str, searchValue) {
+        var charToFind = searchValue[0];
+        for(var i=0,len=str.length;i<len && searchValue.length>0;i++) {
+            if(str[i] === charToFind) {
+                searchValue = searchValue.substring(1);
+                if(searchValue.length === 0) {
+                    i++;
+                    break;
+                }
+                charToFind = searchValue[0];
+            }
+        }
+
+        if(searchValue.length > 0) return -1;
+        else return i;
+    },
+
+
     // replace any existing dial code with the new one
     _updateNumber: function(dialCode) {
       var inputVal = this.telInput.val();
@@ -381,7 +400,7 @@
       // if the previous number contained a valid dial code, replace it
       // (if more than just a plus character)
       if (prevDialCode.length > 1) {
-        newNumber = inputVal.replace(prevDialCode, newDialCode);
+        newNumber = newDialCode + inputVal.substring(this._findEndOfStringIgnoreNonConsecutive(inputVal, prevDialCode));
         // if the old number was just the dial code,
         // then we will need to add the space again
         if (inputVal == prevDialCode) {


### PR DESCRIPTION
You can reproduce the bug by doing the following:
1. Go to the [demo page](http://jackocnr.com/intl-tel-input.html)
2. Paste this phone number into the box: `+1.3451234567`
3. Notice that the flag correctly updates to show Cayman Islands as the country
4. Click on the flag and change the country to something else, like Cameroon (+237)

Expected Result:
- Phone number should change to `+237 1234567`

Actual Result:
- Phone number does not change

This only affects countries with four-digit dialing codes.  In reality, I think these are country code 1 and these small countries have an area code assigned to them.. but that's another discussion.
