### PR TITLE
Canadian area codes

### DIFF
--- a/src/js/data.js
+++ b/src/js/data.js
@@ -135,10 +135,6 @@ var allCountries = $.each([{
   i: "bo",
   d: "591"
 }, {
-  n: "Caribbean Netherlands",
-  i: "bq",
-  d: "5997"
-}, {
   n: "Bosnia and Herzegovina (Босна и Херцеговина)",
   i: "ba",
   d: "387"
@@ -190,6 +186,10 @@ var allCountries = $.each([{
   n: "Cape Verde (Kabu Verdi)",
   i: "cv",
   d: "238"
+}, {
+  n: "Caribbean Netherlands",
+  i: "bq",
+  d: "5997"
 }, {
   n: "Cayman Islands",
   i: "ky",


### PR DESCRIPTION
Adds Canadian area codes to data.js so that the country flag changes accordingly if the user enters a Canadian number. The list was taken from http://en.wikipedia.org/wiki/List_of_North_American_Numbering_Plan_area_codes.

Also fixes an error in the country ordering.
