### PR TITLE
fixed angularJS keydown event not-bubbling and not updating model

### DIFF
--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -416,6 +416,8 @@
         }
         input.setSelectionRange(newCursor, newCursor);
       }
+      
+      this.telInput.trigger("change"); //fix for angularJS keydown event not-bubbling and not updating model
     },
 
 


### PR DESCRIPTION
If script is used as angular js directive, then changing input gets triggered only on delete or backspace. 
This is caused by e.preventDefault(); in keydown handling, that intercepts change events that angular is listening to update model
This fix causes another change event to fire
