### PR TITLE
Added showPlaceholder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Note: any options that take country codes should be lower case [ISO 3166-1 alpha
 Type: `Boolean` Default: `true`  
 Format the number on each keypress according to the country-specific formatting rules. This will also prevent the user from entering invalid characters (triggering a red flash in the input - see [Troubleshooting](#troubleshooting) to customise this). Requires the `utilsScript` option.
 
+**autoPlaceholder**  
+Type: `Boolean` Default: `true`  
+Add or remove input placeholder with an example number for the selected country. Requires the `utilsScript` option.
+
 **autoHideDialCode**  
 Type: `Boolean` Default: `true`  
 If there is just a dial code in the input: remove it on blur, and re-add it on focus. This is to prevent just a dial code getting submitted with the form.

--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -18,7 +18,9 @@ var pluginName = "intlTelInput",
     // the countries at the top of the list. defaults to united states and united kingdom
     preferredCountries: ["us", "gb"],
     // specify the path to the libphonenumber script to enable validation/formatting
-    utilsScript: ""
+    utilsScript: "",
+    // add or remove input placeholder with an example number for the selected country
+    showPlaceholder: true
   },
   keys = {
     UP: 38,
@@ -873,7 +875,7 @@ Plugin.prototype = {
 
   // update the input placeholder to an example number from the currently selected country
   _updatePlaceholder: function() {
-    if (window.intlTelInputUtils && !this.hadInitialPlaceholder) {
+    if (window.intlTelInputUtils && !this.hadInitialPlaceholder && this.options.showPlaceholder) {
       var iso2 = this.selectedCountryData.iso2,
         numberType = intlTelInputUtils.numberType[this.options.numberType || "FIXED_LINE"],
         placeholder = (iso2) ? intlTelInputUtils.getExampleNumber(iso2, this.options.nationalMode, numberType) : "";

--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -20,7 +20,7 @@ var pluginName = "intlTelInput",
     // specify the path to the libphonenumber script to enable validation/formatting
     utilsScript: "",
     // add or remove input placeholder with an example number for the selected country
-    showPlaceholder: true
+    autoPlaceholder: true
   },
   keys = {
     UP: 38,
@@ -875,7 +875,7 @@ Plugin.prototype = {
 
   // update the input placeholder to an example number from the currently selected country
   _updatePlaceholder: function() {
-    if (window.intlTelInputUtils && !this.hadInitialPlaceholder && this.options.showPlaceholder) {
+    if (window.intlTelInputUtils && !this.hadInitialPlaceholder && this.options.autoPlaceholder) {
       var iso2 = this.selectedCountryData.iso2,
         numberType = intlTelInputUtils.numberType[this.options.numberType || "FIXED_LINE"],
         placeholder = (iso2) ? intlTelInputUtils.getExampleNumber(iso2, this.options.nationalMode, numberType) : "";


### PR DESCRIPTION
In some cases you don't need input placeholder. This option allows to turn off it.
(There's placeholder, when input field in empty. Some users may think it's phone number inputted in the field. I know it sounds unlikely, but can happen)