### PR TITLE
Correct example code when using Bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,11 @@ In order to get the automatic country-specific placeholders, simply omit the pla
 **Bootstrap input groups**  
 Simply add this line to get [input groups](http://getbootstrap.com/components/#input-groups) working properly.
 ```css
-.intl-tel-input {display: table-cell;}
+.intl-tel-input {
+  width: 100%;
+  text-align:left;
+  padding-top: 5px;
+}
 ```
 
 


### PR DESCRIPTION
Fix for [Related:](#148) this tweak will allow the '[tel]' input field to work with a responsive UI.

[Working example](http://codepen.io/gegere/pen/vEexzJ) - I went a different route as I was trying to use the purposed which looks good on all browsers but does not function correctly on iOS Safari:

`.intl-tel-input {display: table-cell;}`

On iOS Safari the following function does not fire, as I can able to test and confirm.
```
_showDropdown: function() {
    alert('hello');
}
```