### PR TITLE
add intl-tel-mobile-select class for mobile select elements

### DIFF
--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -223,7 +223,7 @@ Plugin.prototype = {
     // desktop is a proper list containing: preferred countries, then divider, then all countries
     if (this.isMobile) {
       this.countryList = $("<select>", { 
-        "class": "intl-tel-mobile-select"
+        "class": "iti-mobile-select"
       }).appendTo(this.flagsContainer);
     } else {
       this.countryList = $("<ul>", {

--- a/src/js/intlTelInput.js
+++ b/src/js/intlTelInput.js
@@ -222,7 +222,9 @@ Plugin.prototype = {
     // mobile is just a native select element
     // desktop is a proper list containing: preferred countries, then divider, then all countries
     if (this.isMobile) {
-      this.countryList = $("<select>").appendTo(this.flagsContainer);
+      this.countryList = $("<select>", { 
+        "class": "intl-tel-mobile-select"
+      }).appendTo(this.flagsContainer);
     } else {
       this.countryList = $("<ul>", {
         "class": "country-list v-hide"


### PR DESCRIPTION
I have found multiple themes that modify or change select elements and without having a class it makes it difficult to override or have theme developers add to exclude list.  I noticed the `<ul>` includes a class but the `<select>` does not, so added one to help with these issues.

Add `intl-tel-mobile-select` class to select element for mobile devices