### PR TITLE
Fix geoIpLookup immediate callback issue

### DIFF
--- a/src/js/intlTelInput.js.ejs
+++ b/src/js/intlTelInput.js.ejs
@@ -430,7 +430,9 @@ Plugin.prototype = {
           }
           // tell all instances the auto country is ready
           // TODO: this should just be the current instances
-          $(".intl-tel-input input").intlTelInput("autoCountryLoaded");
+          setTimeout(function() {
+            $(".intl-tel-input input").intlTelInput("autoCountryLoaded");
+          });
         });
       }
     }


### PR DESCRIPTION
Wrapped $(".intl-tel-input input").intlTelInput("autoCountryLoaded"); inside setTimeout to fix issue https://github.com/Bluefieldscom/intl-tel-input/issues/252