### PR TITLE
fix: internal static reference to 'Iti' breaks when minified/mangled

### DIFF
--- a/src/js/intl-tel-input.ts
+++ b/src/js/intl-tel-input.ts
@@ -100,7 +100,7 @@ export class Iti {
     applyOptionSideEffects(this.options);
 
     this.ui = new UI(input, this.options, this.id);
-    this.isAndroid = Iti._getIsAndroid.call(this);
+    this.isAndroid = (this.constructor as typeof Iti)._getIsAndroid();
     this.promise = this._createInitPromises();
 
     //* Process onlyCountries or excludeCountries array if present.


### PR DESCRIPTION
Problem: When using intl-tel-input in a production environment with aggressive minification (like Webpack's TerserPlugin or Vite's Esbuild), the class name Iti is often mangled to a single character (e.g., l). Because the constructor calls Iti._getIsAndroid(), the reference breaks if the minifier doesn't update the hardcoded Iti string inside the class logic.

This results in the error: Uncaught TypeError: l._getIsAndroid is not a function.

Solution: Refactor the call to use this.constructor or ensure the reference is handled dynamically. This ensures that even if the class is renamed during the build process, the static method remains accessible.

Affected line: this.isAndroid = Iti._getIsAndroid(); in the constructor.