### PR TITLE
docs: fix angular component

### DIFF
--- a/angular/demo/form/form.component.ts
+++ b/angular/demo/form/form.component.ts
@@ -14,7 +14,13 @@ import { IntlTelInputComponent } from '../../src/intl-tel-input/angularWithUtils
           initialCountry: 'us',
         }"
       />
-      <button class="button" type="submit" [disabled]="!fg.valid">
+      <button 
+        class="button" 
+        type="submit" 
+        [disabled]="!fg.valid"
+        [style.opacity]="fg.valid ? '1' : '0.5'"
+        [style.cursor]="fg.valid ? 'pointer' : 'not-allowed'"
+      >
         Validate
       </button>
       <div class="notice">
@@ -45,7 +51,6 @@ export class AppComponent {
   }
 
   handleSubmit(): void {
-    this.phone?.markAsTouched();
     if (this.fg.valid) {
       this.notice = `Valid number: ${this.telInput.getInstance()?.getNumber()}`;
     }

--- a/site/src/examples/js/angular_component.ts.ejs
+++ b/site/src/examples/js/angular_component.ts.ejs
@@ -16,8 +16,14 @@ import { IntlTelInputComponent } from "../../../build/intl-tel-input/angular/Int
         [initOptions]="initOptions"
       />
       <span>&nbsp;</span>
-      <button class="button" type="submit" [disabled]="!fg.valid">
-        Validate
+      <button
+        class="button"
+        type="submit"
+        [disabled]="!fg.valid"
+        [style.opacity]="fg.valid ? '1' : '0.5'"
+        [style.cursor]="fg.valid ? 'pointer' : 'not-allowed'"
+      >
+          Validate
       </button>
       <div class="notice">
         @if (phone?.errors?.["required"] && phone?.touched) {
@@ -52,7 +58,6 @@ export class AppComponent {
   }
 
   handleSubmit(): void {
-    this.phone?.markAsTouched();
     if (this.fg.valid) {
       this.notice = `Valid number: ${this.telInput.getInstance()?.getNumber()}`;
     }

--- a/site/src/examples/js/angular_component_display_code.ts
+++ b/site/src/examples/js/angular_component_display_code.ts
@@ -13,7 +13,13 @@ import "intl-tel-input/styles";
         name="phone"
         [initOptions]="initOptions"
       />
-      <button class="button" type="submit" [disabled]="!fg.valid">
+      <button 
+        class="button" 
+        type="submit" 
+        [disabled]="!fg.valid"
+        [style.opacity]="fg.valid ? '1' : '0.5'"
+        [style.cursor]="fg.valid ? 'pointer' : 'not-allowed'"
+      >
         Validate
       </button>
       <div class="notice">
@@ -49,7 +55,6 @@ export class AppComponent {
   }
 
   handleSubmit(): void {
-    this.phone?.markAsTouched();
     if (this.fg.valid) {
       this.notice = `Valid number: ${this.telInput.getInstance()?.getNumber()}`;
     }


### PR DESCRIPTION
## Fix Angular component example styling

Added visual feedback for the disabled submit button:
- Reduced opacity when form is invalid
- Changed cursor to `not-allowed` for better UX

Also removed unnecessary `markAsTouched()` call since the button is disabled when the form is invalid anyway (I had forgotten that I disabled the button in this example to showcase Angular reactive forms "power").

---

Sorry for the noise with the previous PRs...
