### PR TITLE
feat: add clearOnCountryChange and clearOnDropdownClose options + reset() method

### DIFF
--- a/src/js/intl-tel-input.ts
+++ b/src/js/intl-tel-input.ts
@@ -1190,6 +1190,11 @@ export class Iti {
     // Delegate DOM-only close behaviour to UI
     this.#ui.closeDropdown();
 
+    // Clear search input on dropdown close if option is enabled
+    if (this.#options.clearOnDropdownClose) {
+      this.#ui.handleSearchClear();
+    }
+
     //* Unbind dropdown-scoped events in one go
     this.#dropdownAbortController.abort();
     this.#dropdownAbortController = null;
@@ -1298,6 +1303,10 @@ export class Iti {
 
   //* Trigger the 'countrychange' event.
   #triggerCountryChange(): void {
+    // Clear search input on country change if option is enabled
+    if (this.#options.clearOnCountryChange) {
+      this.#ui.handleSearchClear();
+    }
     this.#trigger(EVENTS.COUNTRY_CHANGE);
   }
 
@@ -1628,6 +1637,11 @@ export class Iti {
     } else {
       this.#ui.selectedCountry.removeAttribute("disabled");
     }
+  }
+
+  //* Clear the search input and reset filtered results.
+  public reset(): void {
+    this.#ui.handleSearchClear();
   }
 
   //********************

--- a/src/js/modules/core/options.ts
+++ b/src/js/modules/core/options.ts
@@ -36,6 +36,10 @@ export const defaults: AllOptions = {
   allowPhonewords: false,
   //* Add a placeholder in the input with an example number for the selected country.
   autoPlaceholder: PLACEHOLDER_MODES.POLITE,
+  //* Clear the search input when the selected country changes.
+  clearOnCountryChange: false,
+  //* Clear the search input when the dropdown is closed.
+  clearOnDropdownClose: false,
   //* Add a custom class to the (injected) container element.
   containerClass: "",
   //* Locale for localising country names via Intl.DisplayNames.

--- a/src/js/modules/types/public-api.ts
+++ b/src/js/modules/types/public-api.ts
@@ -58,6 +58,8 @@ export interface AllOptions {
   allowNumberExtensions: boolean;
   allowPhonewords: boolean;
   autoPlaceholder: ValueOf<typeof PLACEHOLDER_MODES>;
+  clearOnCountryChange: boolean;
+  clearOnDropdownClose: boolean;
   containerClass: string;
   countryNameLocale: string;
   countryOrder: Iso2[] | null;


### PR DESCRIPTION
Fixes #2146

- Add `clearOnCountryChange` option to clear search input when country changes
- Add `clearOnDropdownClose` option to clear search when dropdown closes
- Add public `reset()` method to manually clear search and filtered results

Usage:
```js
// Auto-clear when country changes
const iti = intlTelInput(input, { clearOnCountryChange: true });

// Auto-clear when dropdown closes  
const iti = intlTelInput(input, { clearOnDropdownClose: true });

// Manual reset
iti.reset();
```