### PR TITLE
fix: bind isValidNumber methods to preserve private field access through proxies

### DIFF
--- a/src/js/intl-tel-input.ts
+++ b/src/js/intl-tel-input.ts
@@ -103,6 +103,11 @@ export class Iti {
     this.#numerals = new Numerals(input.value);
     this.promise = this.#createInitPromises(this.#options);
 
+    //* Bind public methods to preserve private field access when instance is wrapped in a Proxy
+    //* This fixes issues with reactive frameworks (e.g., Alpine.js) that proxy the instance
+    this.isValidNumber = this.isValidNumber.bind(this);
+    this.isValidNumberPrecise = this.isValidNumberPrecise.bind(this);
+
     //* Process onlyCountries or excludeCountries array if present.
     this.#countries = processAllCountries(this.#options);
 


### PR DESCRIPTION
## Problem

When the <code>Iti</code> instance is wrapped in a JavaScript Proxy (e.g., by Alpine.js or other reactive frameworks), calling <code>isValidNumber()</code> throws an error:

> Uncaught TypeError: can't access private field or method: object is not the right class

This happens because private fields are tied to the original object, not the proxy.

## Solution

Bind the <code>isValidNumber()</code> and <code>isValidNumberPrecise()</code> methods in the constructor, ensuring they maintain the correct 'this' context and private field access even when called through a proxy.

## Changes

- Added method bindings in the constructor for <code>isValidNumber</code> and <code>isValidNumberPrecise</code>

## Testing

Verified that bound methods preserve private field access when accessed through a Proxy:



Fixes #2149