### PR TITLE
fix(vue): respect kebab-case props in initOptions

### DIFF
--- a/vue/src/IntlTelInput.vue
+++ b/vue/src/IntlTelInput.vue
@@ -73,12 +73,19 @@ const pluginOptionKeys = Object.keys(intlTelInput.defaults);
 // To preserve plugin defaults, only pass through keys that:
 // 1) are real plugin option keys, and
 // 2) were actually provided by the parent
+//
+// We normalize raw vnode prop keys to camelCase before checking, because Vue's
+// template compiler may pass props in kebab-case depending on how the consumer
+// writes the attribute.
 const initOptions = computed<SomeOptions>(() => {
   const rawPassedProps = (vm?.vnode.props ?? {}) as Record<string, unknown>;
+  const passedCamelKeys = new Set(
+    Object.keys(rawPassedProps).map((k) => k.replace(/-([a-z])/g, (_, c) => c.toUpperCase())),
+  );
 
   const cleanedOptions: Record<string, unknown> = {};
   pluginOptionKeys.forEach((optionKey) => {
-    if (!Object.hasOwn(rawPassedProps, optionKey)) {
+    if (!passedCamelKeys.has(optionKey)) {
       return;
     }
     const value = (props as Record<string, unknown>)[optionKey];


### PR DESCRIPTION
## Problem

`initOptions` checks `vm.vnode.props` to detect which plugin options were explicitly passed (so Vue's boolean-coercion default of `false` doesn't clobber the plugin's own defaults). However, Vue's template compiler sometimes emits prop names in kebab-case (e.g. `initial-country` instead of `initialCountry`), so the `Object.hasOwn` check missed them and those options were silently dropped.

```vue
<!-- Doesn't work, but should -->
<IntlTelInput initial-country="se" />

<!-- Works -->
<IntlTelInput initialCountry="se" />
```

## Fix

Normalize all raw vnode prop keys to camelCase upfront (via a single `-([a-z])` → uppercase pass) into a `Set`, then check against that. This means both `initialCountry` and `initial-country` in the consumer's template will correctly flow through to the plugin initialisation call.