### PR TITLE
fix: allow native paste events in strictMode

### DIFF
--- a/packages/core/src/js/intlTelInput.ts
+++ b/packages/core/src/js/intlTelInput.ts
@@ -548,10 +548,13 @@ export class Iti {
       return;
     }
     let inputValue = this.#getTelInputValue();
+    const isPaste = e?.inputType === INPUT_TYPES.PASTE;
+    const isStrictPaste = strictMode && isPaste;
 
     //* Android workaround for handling plus when separateDialCode enabled
     if (
       this.#isAndroid &&
+      !isPaste &&
       e?.data === "+" &&
       separateDialCode &&
       allowDropdown &&
@@ -564,6 +567,7 @@ export class Iti {
     //* Android strictMode workaround: the keydown-based filter can't block these
     if (
       this.#isAndroid &&
+      !isPaste &&
       strictMode &&
       (e?.data === " " || e?.data === "-" || e?.data === ".")
     ) {
@@ -571,13 +575,11 @@ export class Iti {
       return;
     }
 
-    let didHandleStrictPaste = false;
-    if (strictMode && e?.inputType === INPUT_TYPES.PASTE) {
-      const didRejectPaste = this.#handleStrictPasteInputEvent(inputValue);
+    if (isStrictPaste) {
+      const didRejectPaste = this.#handleStrictPasteInputEvent();
       if (didRejectPaste) {
         return;
       }
-      didHandleStrictPaste = true;
       inputValue = this.#getTelInputValue();
     }
 
@@ -588,9 +590,9 @@ export class Iti {
 
     //* If user types their own formatting char (not a plus or a numeric), or they paste something, then set the override.
     const isFormattingChar =
-      !didHandleStrictPaste && e?.data && REGEX.NON_PLUS_NUMERIC.test(e.data);
-    const isPaste = e?.inputType === INPUT_TYPES.PASTE && inputValue;
-    if (isFormattingChar || (isPaste && !strictMode)) {
+      !isStrictPaste && e?.data && REGEX.NON_PLUS_NUMERIC.test(e.data);
+    const isNonStrictPaste = isPaste && inputValue && !strictMode;
+    if (isFormattingChar || isNonStrictPaste) {
       this.#userOverrideFormatting = true;
     } else if (!REGEX.NON_PLUS_NUMERIC.test(inputValue)) {
       //* If user removes all formatting chars, then reset the override.
@@ -722,15 +724,18 @@ export class Iti {
 
   // Handle paste input events when strictMode is enabled by sanitising the pasted content after
   // the browser inserts it, and rejecting it entirely if it would result in an invalid number.
-  #handleStrictPasteInputEvent(inputValue: string): boolean {
+  #handleStrictPasteInputEvent(): boolean {
     const input = this.#ui.telInputEl;
     const pasteSnapshot = this.#strictPasteSnapshot;
     this.#strictPasteSnapshot = null;
+    if (!pasteSnapshot) {
+      return false;
+    }
 
-    const pastedRaw = pasteSnapshot?.pastedRaw ?? inputValue;
-    const originalValue = pasteSnapshot?.value ?? "";
-    const selStart = pasteSnapshot?.selectionStart ?? originalValue.length;
-    const selEnd = pasteSnapshot?.selectionEnd ?? originalValue.length;
+    const pastedRaw = pasteSnapshot.pastedRaw;
+    const originalValue = pasteSnapshot.value;
+    const selStart = pasteSnapshot.selectionStart;
+    const selEnd = pasteSnapshot.selectionEnd;
     const before = originalValue.slice(0, selStart);
     const after = originalValue.slice(selEnd);
     const iso2 = this.#selectedCountry?.iso2;
@@ -830,13 +835,8 @@ export class Iti {
   }
 
   #restoreValueBeforeStrictPaste(
-    pasteSnapshot: StrictPasteSnapshot | null,
+    pasteSnapshot: StrictPasteSnapshot,
   ): void {
-    if (!pasteSnapshot) {
-      this.#setTelInputValue("");
-      this.#ui.telInputEl.setSelectionRange(0, 0);
-      return;
-    }
     this.#setTelInputValue(pasteSnapshot.value);
     this.#ui.telInputEl.setSelectionRange(
       pasteSnapshot.selectionStart,

--- a/packages/core/src/js/intlTelInput.ts
+++ b/packages/core/src/js/intlTelInput.ts
@@ -56,6 +56,14 @@ import {
 export { NUMBER_FORMAT, NUMBER_TYPE, VALIDATION_ERROR } from "./constants.js";
 import { Numerals } from "./core/numerals.js";
 import type { ForEachInstanceArgsMap } from "./types/forEachInstanceArgsMap.js";
+
+type StrictPasteSnapshot = {
+  pastedRaw: string;
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+};
+
 // Re-export the full public type surface, so consumers who resolve
 // "intl-tel-input" to this source file (via tsconfig paths) see the same
 // exports as consumers of the bundled dist/js/intlTelInput.d.ts. Without
@@ -141,6 +149,7 @@ export class Iti {
   #numerals!: Numerals;
   //* Tracks whether the user has typed/pasted their own formatting chars, so AYT-formatting should back off.
   #userOverrideFormatting = false;
+  #strictPasteSnapshot: StrictPasteSnapshot | null = null;
 
   #autoCountryDeferred?: Deferred<void>;
   #utilsDeferred?: Deferred<void>;
@@ -538,7 +547,7 @@ export class Iti {
     if (detail?.["isCountryChange"]) {
       return;
     }
-    const inputValue = this.#getTelInputValue();
+    let inputValue = this.#getTelInputValue();
 
     //* Android workaround for handling plus when separateDialCode enabled
     if (
@@ -562,13 +571,24 @@ export class Iti {
       return;
     }
 
+    let didHandleStrictPaste = false;
+    if (strictMode && e?.inputType === INPUT_TYPES.PASTE) {
+      const didRejectPaste = this.#handleStrictPasteInputEvent(inputValue);
+      if (didRejectPaste) {
+        return;
+      }
+      didHandleStrictPaste = true;
+      inputValue = this.#getTelInputValue();
+    }
+
     //* Update selected country.
     if (this.#updateCountryFromNumber(inputValue)) {
       this.#dispatchCountryChangeEvent();
     }
 
     //* If user types their own formatting char (not a plus or a numeric), or they paste something, then set the override.
-    const isFormattingChar = e?.data && REGEX.NON_PLUS_NUMERIC.test(e.data);
+    const isFormattingChar =
+      !didHandleStrictPaste && e?.data && REGEX.NON_PLUS_NUMERIC.test(e.data);
     const isPaste = e?.inputType === INPUT_TYPES.PASTE && inputValue;
     if (isFormattingChar || (isPaste && !strictMode)) {
       this.#userOverrideFormatting = true;
@@ -687,25 +707,39 @@ export class Iti {
     });
   }
 
-  // Handle paste events when strictMode is enabled by sanitising the pasted content before it's inserted into the input, and rejecting it entirely if it would result in an invalid number
+  // In strict mode, remember paste details before the browser inserts the pasted text.
+  // The actual sanitisation runs on the following input event so native paste stays enabled.
   #handleStrictPasteEvent = (e: ClipboardEvent): void => {
-    // in strict mode we always control the pasted value
-    e.preventDefault();
-
-    // shortcuts
     const input = this.#ui.telInputEl;
-    const selStart = input.selectionStart;
-    const selEnd = input.selectionEnd;
     const inputValue = this.#getTelInputValue();
-    const before = inputValue.slice(0, selStart ?? undefined);
-    const after = inputValue.slice(selEnd ?? undefined);
+    this.#strictPasteSnapshot = {
+      pastedRaw: e.clipboardData?.getData("text") ?? "",
+      value: inputValue,
+      selectionStart: input.selectionStart ?? inputValue.length,
+      selectionEnd: input.selectionEnd ?? inputValue.length,
+    };
+  };
+
+  // Handle paste input events when strictMode is enabled by sanitising the pasted content after
+  // the browser inserts it, and rejecting it entirely if it would result in an invalid number.
+  #handleStrictPasteInputEvent(inputValue: string): boolean {
+    const input = this.#ui.telInputEl;
+    const pasteSnapshot = this.#strictPasteSnapshot;
+    this.#strictPasteSnapshot = null;
+
+    const pastedRaw = pasteSnapshot?.pastedRaw ?? inputValue;
+    const originalValue = pasteSnapshot?.value ?? "";
+    const selStart = pasteSnapshot?.selectionStart ?? originalValue.length;
+    const selEnd = pasteSnapshot?.selectionEnd ?? originalValue.length;
+    const before = originalValue.slice(0, selStart);
+    const after = originalValue.slice(selEnd);
     const iso2 = this.#selectedCountry?.iso2;
 
-    const pastedRaw = e.clipboardData!.getData("text");
     const pasted = this.#numerals.normalise(pastedRaw);
     // only allow a plus in the pasted content if there's not already one in the input, or the existing one is selected to be replaced by the pasted content
-    const initialCharSelected = selStart === 0 && selEnd! > 0;
-    const allowLeadingPlus = !inputValue.startsWith("+") || initialCharSelected;
+    const initialCharSelected = selStart === 0 && selEnd > 0;
+    const allowLeadingPlus =
+      !originalValue.startsWith("+") || initialCharSelected;
     // just numerics and pluses
     const allowedChars = pasted.replace(REGEX.NON_PLUS_NUMERIC_GLOBAL, "");
     const hasLeadingPlus = allowedChars.startsWith("+");
@@ -728,7 +762,8 @@ export class Iti {
         rejectedInput: pastedRaw,
         reason: "max-length",
       });
-      return;
+      this.#restoreValueBeforeStrictPaste(pasteSnapshot);
+      return true;
     }
 
     // utils.getCoreNumber doesn't work for very short numbers, so only bother checking once we have a few chars
@@ -750,13 +785,14 @@ export class Iti {
           rejectedInput: pastedRaw,
           reason: "max-length",
         });
-        return;
+        this.#restoreValueBeforeStrictPaste(pasteSnapshot);
+        return true;
       }
       if (
         this.#maxCoreNumberLength &&
         coreNumber.length > this.#maxCoreNumberLength
       ) {
-        if (input.selectionEnd === inputValue.length) {
+        if (selEnd === originalValue.length) {
           // if they try to paste too many digits at the end, then just trim the excess
           const trimLength = coreNumber.length - this.#maxCoreNumberLength;
           newValue = newValue.slice(0, newValue.length - trimLength);
@@ -769,17 +805,15 @@ export class Iti {
             rejectedInput: pastedRaw,
             reason: "max-length",
           });
-          return;
+          this.#restoreValueBeforeStrictPaste(pasteSnapshot);
+          return true;
         }
       }
     }
     // preserve pasted numeral set in display
     this.#setTelInputValue(newValue);
-    const caretPos = selStart! + sanitised.length;
+    const caretPos = selStart + sanitised.length;
     input.setSelectionRange(caretPos, caretPos);
-
-    // trigger format-as-you-type and country update etc
-    input.dispatchEvent(new InputEvent("input", { bubbles: true }));
 
     if (rejectReason) {
       // If the paste had content but every character was stripped, treat it as a whole-input rejection.
@@ -792,7 +826,23 @@ export class Iti {
         reason: rejectReason,
       });
     }
-  };
+    return false;
+  }
+
+  #restoreValueBeforeStrictPaste(
+    pasteSnapshot: StrictPasteSnapshot | null,
+  ): void {
+    if (!pasteSnapshot) {
+      this.#setTelInputValue("");
+      this.#ui.telInputEl.setSelectionRange(0, 0);
+      return;
+    }
+    this.#setTelInputValue(pasteSnapshot.value);
+    this.#ui.telInputEl.setSelectionRange(
+      pasteSnapshot.selectionStart,
+      pasteSnapshot.selectionEnd,
+    );
+  }
 
   //* Adhere to the input's maxlength attr.
   #truncateToMaxLength(number: string): string {

--- a/tests/integration/core/easternNumerals.test.js
+++ b/tests/integration/core/easternNumerals.test.js
@@ -3,12 +3,11 @@
  */
 
 import { userEvent } from "@testing-library/user-event";
-import { fireEvent } from "@testing-library/dom";
 import {
   initIntlTelInput,
   teardown,
   checkFlagSelected,
-  getPasteEventObject,
+  pasteIntoInput,
 } from "../helpers/helpers";
 
 // "Eastern" numerals that are still used for phone numbers in some countries:
@@ -116,8 +115,7 @@ describe("Eastern numerals support", () => {
     test("pasting intl number with Arabic-Indic digits is allowed", async () => {
       await user.click(input);
       const pastedContent = "+١٩٨٧١٢٣١٢٣٤"; // "+19871231234"
-      const eventObject = getPasteEventObject(pastedContent);
-      fireEvent.paste(input, eventObject);
+      expect(pasteIntoInput(input, pastedContent)).toBe(true);
       // Display should preserve Eastern Arabic numerals while formatting: +1 987-123-1234
       expect(input.value).toBe("+١٩٨٧١٢٣١٢٣٤");
     });

--- a/tests/integration/helpers/helpers.js
+++ b/tests/integration/helpers/helpers.js
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+import { fireEvent } from "@testing-library/dom";
 import intlTelInputWithUtils from "intl-tel-input/intlTelInputWithUtils";
 
 export const intlTelInput = intlTelInputWithUtils;
@@ -174,4 +175,24 @@ export const getPasteEventObject = (str) => {
       getData: () => str,
     },
   };
+};
+
+export const pasteIntoInput = (input, str) => {
+  const pasteAllowed = fireEvent.paste(input, getPasteEventObject(str));
+
+  if (pasteAllowed) {
+    const selStart = input.selectionStart ?? input.value.length;
+    const selEnd = input.selectionEnd ?? input.value.length;
+    const before = input.value.slice(0, selStart);
+    const after = input.value.slice(selEnd);
+    input.value = before + str + after;
+    const caretPos = selStart + str.length;
+    input.setSelectionRange(caretPos, caretPos);
+    fireEvent.input(input, {
+      inputType: "insertFromPaste",
+      data: str,
+    });
+  }
+
+  return pasteAllowed;
 };

--- a/tests/integration/options/strictMode.test.js
+++ b/tests/integration/options/strictMode.test.js
@@ -3,12 +3,14 @@
  */
 
 import { userEvent } from "@testing-library/user-event";
+import { fireEvent } from "@testing-library/dom";
 import {
   initIntlTelInput,
   teardown,
   stripFormattingChars,
   selectCountryAndTypePlaceholderNumberAsync,
   checkFlagSelected,
+  isDropdownOpen,
   pasteIntoInput,
 } from "../helpers/helpers";
 
@@ -195,6 +197,20 @@ describe("strictMode option", () => {
       expect(pasteIntoInput(input, "2345678901")).toBe(true);
     });
 
+    test("does not clear long content if a paste input event has no paste snapshot", () => {
+      const events = [];
+      input.addEventListener("strict:reject", (e) => events.push(e.detail));
+      const inputValue = "234567890123456789012345678901";
+      input.value = inputValue;
+      input.setSelectionRange(inputValue.length, inputValue.length);
+      fireEvent.input(input, {
+        inputType: "insertFromPaste",
+        data: inputValue,
+      });
+      expect(events).toEqual([]);
+      expect(input.value).toBe(inputValue);
+    });
+
     // PREV BUG
     test("pasting a very long number still works", async () => {
       await user.click(input);
@@ -333,6 +349,52 @@ describe("strictMode option", () => {
       await user.type(input, "1");
       // sometimes AYT formatting is slightly different, so strip formatting chars
       expect(stripFormattingChars(input.value)).toBe(placeholderNumberClean);
+    });
+  });
+
+  describe("Android paste handling", () => {
+    let input, iti, user, container;
+
+    beforeEach(() => {
+      user = userEvent.setup();
+      vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue(
+        "Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36",
+      );
+    });
+
+    afterEach(() => {
+      teardown(iti);
+    });
+
+    test("handles pasted plus as paste instead of opening country search", async () => {
+      ({ input, iti, container } = initIntlTelInput({
+        options: {
+          strictMode: true,
+          separateDialCode: true,
+          initialCountry: "us",
+        },
+      }));
+      await user.click(input);
+
+      expect(pasteIntoInput(input, "+")).toBe(true);
+      expect(isDropdownOpen(container)).toBe(false);
+      expect(input.value).toBe("+");
+    });
+
+    test("handles pasted invalid chars as paste instead of Android typed input", async () => {
+      ({ input, iti } = initIntlTelInput({
+        options: {
+          strictMode: true,
+          initialCountry: "us",
+        },
+      }));
+      const events = [];
+      input.addEventListener("strict:reject", (e) => events.push(e.detail));
+      await user.click(input);
+
+      expect(pasteIntoInput(input, " ")).toBe(true);
+      expect(events).toEqual([{ source: "paste", rejectedInput: " ", reason: "invalid" }]);
+      expect(input.value).toBe("");
     });
   });
 

--- a/tests/integration/options/strictMode.test.js
+++ b/tests/integration/options/strictMode.test.js
@@ -3,14 +3,13 @@
  */
 
 import { userEvent } from "@testing-library/user-event";
-import { fireEvent } from "@testing-library/dom";
 import {
   initIntlTelInput,
   teardown,
   stripFormattingChars,
   selectCountryAndTypePlaceholderNumberAsync,
   checkFlagSelected,
-  getPasteEventObject,
+  pasteIntoInput,
 } from "../helpers/helpers";
 
 
@@ -186,19 +185,22 @@ describe("strictMode option", () => {
     test("paste strips invalid chars, caps length, and formats", async () => {
       await user.click(input);
       const pastedContent = "+1a9./-:$@&*b8c7d+123123456";
-      const eventObject = getPasteEventObject(pastedContent);
-      // NOTE: could not get this working with user.paste
-      fireEvent.paste(input, eventObject);
+      const pasteAllowed = pasteIntoInput(input, pastedContent);
+      expect(pasteAllowed).toBe(true);
       expect(input.value).toBe("+1 987-123-1234");
+    });
+
+    test("does not prevent the paste event in strictMode", async () => {
+      await user.click(input);
+      expect(pasteIntoInput(input, "2345678901")).toBe(true);
     });
 
     // PREV BUG
     test("pasting a very long number still works", async () => {
       await user.click(input);
       const pastedContent = "2345678901234567999999";
-      const eventObject = getPasteEventObject(pastedContent);
-      // NOTE: could not get this working with user.paste
-      fireEvent.paste(input, eventObject);
+      const pasteAllowed = pasteIntoInput(input, pastedContent);
+      expect(pasteAllowed).toBe(true);
       expect(input.value).toBe("(234) 567-8901");
     });
 
@@ -222,7 +224,7 @@ describe("strictMode option", () => {
       input.addEventListener("strict:reject", (e) => events.push(e.detail));
       await user.click(input);
       const pastedContent = "a9871234567";
-      fireEvent.paste(input, getPasteEventObject(pastedContent));
+      expect(pasteIntoInput(input, pastedContent)).toBe(true);
       expect(events).toEqual([{ source: "paste", rejectedInput: pastedContent, reason: "invalid" }]);
     });
 
@@ -231,7 +233,7 @@ describe("strictMode option", () => {
       input.addEventListener("strict:reject", (e) => events.push(e.detail));
       await user.click(input);
       const pastedContent = "2345678901234567999999";
-      fireEvent.paste(input, getPasteEventObject(pastedContent));
+      expect(pasteIntoInput(input, pastedContent)).toBe(true);
       expect(events).toEqual([{ source: "paste", rejectedInput: pastedContent, reason: "max-length" }]);
     });
 
@@ -239,7 +241,7 @@ describe("strictMode option", () => {
       const events = [];
       input.addEventListener("strict:reject", (e) => events.push(e.detail));
       await user.click(input);
-      fireEvent.paste(input, getPasteEventObject("2345678901"));
+      expect(pasteIntoInput(input, "2345678901")).toBe(true);
       expect(events).toEqual([]);
     });
   });
@@ -366,13 +368,13 @@ describe("strictMode option", () => {
     test("does NOT add iti__strict-reject-animation class when paste is only partially stripped", async () => {
       await user.click(input);
       // This paste is partially sanitised (letters stripped) but still accepted.
-      fireEvent.paste(input, getPasteEventObject("a9871234567"));
+      pasteIntoInput(input, "a9871234567");
       expect(container.classList.contains("iti__strict-reject-animation")).toBe(false);
     });
 
     test("adds iti__strict-reject-animation class when every pasted character is stripped", async () => {
       await user.click(input);
-      fireEvent.paste(input, getPasteEventObject("abc"));
+      pasteIntoInput(input, "abc");
       expect(container.classList.contains("iti__strict-reject-animation")).toBe(true);
     });
 
@@ -380,7 +382,7 @@ describe("strictMode option", () => {
       await user.type(input, "7021234567");
       // caret now at end; move it into the middle
       input.setSelectionRange(5, 5);
-      fireEvent.paste(input, getPasteEventObject("99999999"));
+      pasteIntoInput(input, "99999999");
       expect(container.classList.contains("iti__strict-reject-animation")).toBe(true);
     });
 


### PR DESCRIPTION
### Summary

- Allow native `paste` events to proceed when `strictMode` is enabled.
- Store the pre-paste value/selection during `paste`, then sanitise on the following `input` event (`inputType === "insertFromPaste"`).
- Preserve existing strict-mode paste behaviour: invalid characters are stripped, overly long values are capped or rejected, accepted numeral sets are preserved, and `strict:reject` still fires where appropriate.

### Root cause

The strict-mode paste handler previously called `preventDefault()` so it could fully control the pasted value before insertion. That works functionally, but it also causes Lighthouse to report "Prevents users from pasting into input fields" because the native `paste` event is cancelled.

### Testing

- `npx vitest run tests/integration/options/strictMode.test.js tests/integration/core/easternNumerals.test.js`
- `npm run test:js`
- `npm run typecheck:main`
- `npm run lint:js`

Fixes #2167
